### PR TITLE
fix(csv): find the next newline with one scan instead of two

### DIFF
--- a/src/modules/csv/__tests__/csv-large-data.test.ts
+++ b/src/modules/csv/__tests__/csv-large-data.test.ts
@@ -224,6 +224,29 @@ describe("performance", () => {
 
     expect(ms).toBeLessThan(500);
   });
+
+  // Regression: the scanner used to run indexOf("\n") and indexOf("\r") separately per
+  // field. In a file without "\r" the second call walked to the end of the input on
+  // every field, so parse time grew with fields × bytes: ~3 s for this input and
+  // ~40 s for 50 000 rows, while the same data with CRLF endings took ~30 ms.
+  it("parses 20000x14 LF-only rows within 1000ms (newline scan stays linear)", async () => {
+    // generateLargeCsv joins rows with "\n" — no "\r" anywhere in the input.
+    const csv = generateLargeCsv(20000, 14);
+
+    const { result, ms } = await measureTime(() => Csv.parse(csv) as string[][]);
+
+    expect(result).toHaveLength(20001);
+    expect(ms).toBeLessThan(1000);
+  });
+
+  it("parses 20000x14 CR-only rows within 1000ms (newline scan stays linear)", async () => {
+    const csv = generateLargeCsv(20000, 14).replace(/\r?\n/g, "\r");
+
+    const { result, ms } = await measureTime(() => Csv.parse(csv) as string[][]);
+
+    expect(result).toHaveLength(20001);
+    expect(ms).toBeLessThan(1000);
+  });
 });
 
 // =============================================================================

--- a/src/modules/csv/__tests__/parse/scanner.test.ts
+++ b/src/modules/csv/__tests__/parse/scanner.test.ts
@@ -216,6 +216,25 @@ describe("Scanner - Newline Handling", () => {
     expect(rows[1].newline).toBe("\r\n");
     expect(rows[2].newline).toBe("\r");
   });
+
+  it("should scan large LF-only and CR-only inputs to the same fields as CRLF", () => {
+    const rowCount = 5000;
+    const body = Array.from(
+      { length: rowCount },
+      (_, i) => `r${i},alpha,beta,gamma,${i * 7},"quoted, field",delta`
+    );
+
+    const lf = scanAllRows(body.join("\n") + "\n");
+    const cr = scanAllRows(body.join("\r") + "\r");
+    const crlf = scanAllRows(body.join("\r\n") + "\r\n");
+
+    expect(lf).toHaveLength(rowCount);
+    expect(cr.map(row => row.fields)).toEqual(lf.map(row => row.fields));
+    expect(crlf.map(row => row.fields)).toEqual(lf.map(row => row.fields));
+    expect(new Set(lf.map(row => row.newline))).toEqual(new Set(["\n"]));
+    expect(new Set(cr.map(row => row.newline))).toEqual(new Set(["\r"]));
+    expect(new Set(crlf.map(row => row.newline))).toEqual(new Set(["\r\n"]));
+  });
 });
 
 // =============================================================================

--- a/src/modules/csv/parse/scanner/scanner.ts
+++ b/src/modules/csv/parse/scanner/scanner.ts
@@ -56,32 +56,50 @@ export { DEFAULT_SCANNER_CONFIG } from "@csv/parse/scanner/types";
 // =============================================================================
 
 /**
+ * Matches the next line terminator: CRLF, lone CR, or LF. Global so `exec`
+ * resumes from `lastIndex` and returns the first terminator after it.
+ *
+ * One combined search is what keeps field scanning linear. Two separate
+ * `indexOf("\n")` / `indexOf("\r")` calls look equivalent, but each call scans to
+ * the end of the input when its character is absent — and every field of an
+ * LF-only file (or a CR-only file) pays that full scan, so parsing became
+ * O(fields × bytes): ~40 s for a 6.5 MB, 50 000-row LF file that takes ~60 ms
+ * with CRLF endings.
+ */
+const NEWLINE_PATTERN = /\r\n?|\n/g;
+
+/**
  * Find the next newline position and determine its type.
  *
  * @returns [position, length] where length is 1 for \n/\r, 2 for \r\n, or [-1, 0] if not found
  */
 function findNewline(input: string, start: number): [number, number] {
-  const len = input.length;
-  const lfPos = input.indexOf("\n", start);
-  const crPos = input.indexOf("\r", start);
+  NEWLINE_PATTERN.lastIndex = start;
+  const match = NEWLINE_PATTERN.exec(input);
 
   // Neither found
-  if (lfPos === -1 && crPos === -1) {
+  if (match === null) {
     return [-1, 0];
   }
 
-  // Only LF found, or LF comes before CR
-  if (crPos === -1 || (lfPos !== -1 && lfPos < crPos)) {
-    return [lfPos, 1];
+  const pos = match.index;
+  const terminator = match[0];
+
+  if (terminator === "\n") {
+    return [pos, 1];
   }
 
-  // CR found first (or only CR)
-  if (crPos + 1 < len) {
-    return input[crPos + 1] === "\n" ? [crPos, 2] : [crPos, 1];
+  if (terminator === "\r\n") {
+    return [pos, 2];
+  }
+
+  // Lone CR with more input after it
+  if (pos + 1 < input.length) {
+    return [pos, 1];
   }
 
   // CR at end of buffer - might be CRLF, need more data
-  return [crPos, -1]; // -1 signals "maybe CRLF"
+  return [pos, -1]; // -1 signals "maybe CRLF"
 }
 
 /**


### PR DESCRIPTION
## What

`findNewline` in the CSV scanner ran two independent searches per field — `input.indexOf("\n", start)` and `input.indexOf("\r", start)`. Whichever character a file does not contain makes its search walk to the end of the input on **every** field, so parsing an LF-only file (Unix, LibreOffice, most script-generated CSVs) — or a CR-only one — costs O(fields × bytes) instead of O(bytes). CRLF files never hit it, because `"\r"` is always a few characters away.

This replaces the two calls with a single sticky search for the next terminator (`/\r\n?|\n/g` with `lastIndex`), which stops at the first `\r` or `\n` it meets. The return contract of `findNewline` — `[position, length]`, with `-1` for "lone CR at buffer end, might be CRLF" — is unchanged, so the streaming resume logic is untouched.

## Measured

Same 14-column data, `Csv.parse` on Node 25, before → after:

| Rows | Size | LF-only before | LF-only after | CRLF (unaffected) |
| ---: | ---: | ---: | ---: | ---: |
| 10 000 | 1.3 MB | 703 ms | 19 ms | 16 ms |
| 20 000 | 2.6 MB | 2 885 ms | 21 ms | 30 ms |
| 50 000 | 6.5 MB | ~38 s | 59 ms | 64 ms |

`lineEnding` did not help before the fix: `findNewline` does not consult it.

## Tests

- `scanner.test.ts` — "Scanner - Newline Handling": 5 000-row LF-only, CR-only and CRLF inputs must scan to identical fields and report their own terminator.
- `csv-large-data.test.ts` — "performance": 20 000 × 14 LF-only and CR-only inputs must parse within 1 000 ms. With the previous scanner both take ~1.5 s on a fast workstation and longer on CI, so they fail as intended; after the fix they take tens of milliseconds.

`pnpm check` and the full `src/modules/csv` suite (14 files, 677 tests) pass.
